### PR TITLE
Select Fields Hotfix

### DIFF
--- a/django_glue/templates/django_glue/form/glue_field/search_and_select_field.html
+++ b/django_glue/templates/django_glue/form/glue_field/search_and_select_field.html
@@ -23,6 +23,10 @@
                 $watch('value', (value) => {
                     this.update_choice();
                 });
+
+                $watch('glue_field.choices', () => {
+                    this.update_choice();
+                });
             },
 
             get filtered_choices() {

--- a/django_glue/templates/django_glue/form/glue_field/select_field.html
+++ b/django_glue/templates/django_glue/form/glue_field/select_field.html
@@ -21,6 +21,10 @@
                 $watch('value', (value) => {
                     this.update_choice();
                 });
+
+                $watch('glue_field.choices', () => {
+                    this.update_choice();
+                });
             },
 
             update_choice() {


### PR DESCRIPTION
- The select field component was not displaying the selected value for options that were loaded asynchronously. This affected forms where choices are populated after initialization.
- I have added a watcher on the `glue_field.choices` that triggers the `update_choice()` method whenever choices are updated.