### PR TITLE
Update keep live to reliably prompt page refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: stratusadv/github-actions/linting@v1
         with:
           python-version: '3.11'
+          template-lint-extras: ''
 
   tests:
     name: Tests

--- a/django_glue/constants.py
+++ b/django_glue/constants.py
@@ -1,4 +1,4 @@
-__VERSION__ = '0.8.12'
+__VERSION__ = '0.8.13'
 
 UNIQUE_NAME_KEY = 'unique_name'
 ACTION_KEY = 'action'

--- a/django_glue/static/django_glue/js/session/keep_live.js
+++ b/django_glue/static/django_glue/js/session/keep_live.js
@@ -11,20 +11,24 @@ class DjangoGlueKeepLive {
         this.last_updated_datetime_milliseconds = Date.now()
     }
 
-    check_expired() {
+    clear_pulse_interval() {
+        if (this.keep_live_interval_handle) {
+            clearInterval(this.keep_live_interval_handle)
+            this.keep_live_interval_handle = null
+        }
+    }
 
+    check_expired() {
         const now_last_expired_delta = (Date.now() - this.last_updated_datetime_milliseconds)
         let is_expired = now_last_expired_delta > (this.keep_live_interval_milliseconds + 5000)
 
-
         if (is_expired) {
+            this.clear_pulse_interval()
             this.confirm_reload()
         }
     }
 
     confirm_reload() {
-        clearInterval(this.keep_live_interval_handle)
-
         let confirmation = confirm('Session expired. Do you want to reload the page?')
 
         if (confirmation) {

--- a/django_glue/static/django_glue/js/session/keep_live.js
+++ b/django_glue/static/django_glue/js/session/keep_live.js
@@ -2,8 +2,9 @@ class DjangoGlueKeepLive {
     constructor(keep_live_interval_milliseconds) {
         window.django_glue_keep_live_unique_names = []
         window.django_glue_session_data = {}
-        this.last_updated_datetime_milliseconds = 0
+        this.last_updated_datetime_milliseconds = Date.now()
         this.keep_live_interval_milliseconds = keep_live_interval_milliseconds
+        this.keep_live_interval_handle = null
     }
 
     set_last_updated_date_time() {
@@ -11,18 +12,19 @@ class DjangoGlueKeepLive {
     }
 
     check_expired() {
-        let is_expired = (Date.now() - this.last_updated_datetime_milliseconds) > (this.keep_live_interval_milliseconds + 5000)
+
+        const now_last_expired_delta = (Date.now() - this.last_updated_datetime_milliseconds)
+        let is_expired = now_last_expired_delta > (this.keep_live_interval_milliseconds + 5000)
+
 
         if (is_expired) {
             this.confirm_reload()
-        } else {
-            setTimeout(() => {
-                this.check_expired()
-            }, 3000)
         }
     }
 
     confirm_reload() {
+        clearInterval(this.keep_live_interval_handle)
+
         let confirmation = confirm('Session expired. Do you want to reload the page?')
 
         if (confirmation) {
@@ -37,6 +39,8 @@ class DjangoGlueKeepLive {
     }
 
     async update(keep_live_url) {
+        this.check_expired()
+
         const request_options = {
             method: 'POST',
             headers: {
@@ -55,5 +59,11 @@ class DjangoGlueKeepLive {
         } else {
             this.set_last_updated_date_time()
         }
+    }
+
+    init() {
+        this.keep_live_interval_handle = setInterval(() => {
+            window.django_glue_keep_live.update(DJANGO_GLUE_KEEP_LIVE_URL)
+        }, this.keep_live_interval_milliseconds)
     }
 }

--- a/django_glue/static/django_glue/js/session/keep_live.js
+++ b/django_glue/static/django_glue/js/session/keep_live.js
@@ -1,7 +1,33 @@
 class DjangoGlueKeepLive {
-    constructor() {
+    constructor(keep_live_interval_milliseconds) {
         window.django_glue_keep_live_unique_names = []
         window.django_glue_session_data = {}
+        this.last_updated_datetime_milliseconds = 0
+        this.keep_live_interval_milliseconds = keep_live_interval_milliseconds
+    }
+
+    set_last_updated_date_time() {
+        this.last_updated_datetime_milliseconds = Date.now()
+    }
+
+    check_expired() {
+        let is_expired = (Date.now() - this.last_updated_datetime_milliseconds) > (this.keep_live_interval_milliseconds + 5000)
+
+        if (is_expired) {
+            this.confirm_reload()
+        } else {
+            setTimeout(() => {
+                this.check_expired()
+            }, 3000)
+        }
+    }
+
+    confirm_reload() {
+        let confirmation = confirm('Session expired. Do you want to reload the page?')
+
+        if (confirmation) {
+            window.location.reload()
+        }
     }
 
     add_unique_name(unique_name) {
@@ -25,11 +51,9 @@ class DjangoGlueKeepLive {
         const response = await fetch(keep_live_url, request_options)
 
         if (!response.ok) {
-            let confirmation = confirm('Session expired. Do you want to reload the page?')
-
-            if (confirmation) {
-                window.location.reload()
-            }
+            this.confirm_reload()
+        } else {
+            this.set_last_updated_date_time()
         }
     }
 }

--- a/django_glue/templates/django_glue/django_glue.html
+++ b/django_glue/templates/django_glue/django_glue.html
@@ -22,12 +22,16 @@
     const DJANGO_SESSION_DATA_URL = '{% url 'django_glue:session_data' %}'
     const DJANGO_GLUE_KEEP_LIVE_INTERVAL_TIME_MILLISECONDS = parseInt({{ DJANGO_GLUE_KEEP_LIVE_INTERVAL_TIME_MILLISECONDS }})
 
-    window.django_glue_keep_live = new DjangoGlueKeepLive()
+    window.django_glue_keep_live = new DjangoGlueKeepLive(DJANGO_GLUE_KEEP_LIVE_INTERVAL_TIME_MILLISECONDS)
     window.django_glue_session_data = {{ DJANGO_GLUE_SESSION_DATA|safe }}
 
     setInterval(() => {
         window.django_glue_keep_live.update(DJANGO_GLUE_KEEP_LIVE_URL)
     }, DJANGO_GLUE_KEEP_LIVE_INTERVAL_TIME_MILLISECONDS)
+
+    setTimeout(() => {
+        window.django_glue_keep_live.check_expired()
+    }, 3000)
 </script>
 
 {# Responses #}

--- a/django_glue/templates/django_glue/django_glue.html
+++ b/django_glue/templates/django_glue/django_glue.html
@@ -25,13 +25,7 @@
     window.django_glue_keep_live = new DjangoGlueKeepLive(DJANGO_GLUE_KEEP_LIVE_INTERVAL_TIME_MILLISECONDS)
     window.django_glue_session_data = {{ DJANGO_GLUE_SESSION_DATA|safe }}
 
-    setInterval(() => {
-        window.django_glue_keep_live.update(DJANGO_GLUE_KEEP_LIVE_URL)
-    }, DJANGO_GLUE_KEEP_LIVE_INTERVAL_TIME_MILLISECONDS)
-
-    setTimeout(() => {
-        window.django_glue_keep_live.check_expired()
-    }, 3000)
+    window.django_glue_keep_live.init()
 </script>
 
 {# Responses #}


### PR DESCRIPTION
Updates the keeplive object to check for a expired page (disabled javascript) on each keep live pulse and prompts a page refresh if found