### PR TITLE
Remove FieldGlue proxy and fix file serialization performance

### DIFF
--- a/client_js/src/proxies/fields/base.js
+++ b/client_js/src/proxies/fields/base.js
@@ -1,7 +1,3 @@
-function isInternalProperty(prop) {
-    return typeof prop === 'string' && prop.startsWith('__glue__')
-}
-
 class FieldGlue {
     constructor({owner, name, stateKey, metadata = {}}) {
         this.name = name
@@ -80,48 +76,6 @@ class FieldGlue {
 
     toJSON() {
         return this.value
-    }
-
-    // TODO: this should be deleted
-    asProxy() {
-        const field = this
-        return new Proxy(this, {
-            get(target, prop, receiver) {
-                if (prop === Symbol.iterator) {
-                    return target.value?.[Symbol.iterator]?.bind(target.value)
-                }
-                if (prop === 'then') {
-                    return undefined
-                }
-                target._handlePropertyAccess?.(prop, receiver)
-                if (prop in target) {
-                    return Reflect.get(target, prop, receiver)
-                }
-
-                const value = target.value
-                const member = value?.[prop]
-                return typeof member === 'function' ? member.bind(value) : member
-            },
-            set(target, prop, value, receiver) {
-                if (prop === 'value') {
-                    target.value = value
-                    return true
-                }
-                if (prop in target || isInternalProperty(prop)) {
-                    return Reflect.set(target, prop, value, receiver)
-                }
-
-                const current = target.value
-                if (current && typeof current === 'object') {
-                    current[prop] = value
-                    return true
-                }
-                return Reflect.set(target, prop, value, receiver)
-            },
-            has(target, prop) {
-                return prop in target || prop in Object(field.value ?? {})
-            },
-        })
     }
 }
 

--- a/client_js/src/proxies/fields/index.js
+++ b/client_js/src/proxies/fields/index.js
@@ -13,16 +13,16 @@ function createFieldGlue({owner, name, stateKey, metadata = {}, existingField = 
 
     const options = {owner, name, stateKey, metadata}
     if (metadata.choice_model_path && metadata.type === 'ManyToManyField') {
-        return new ManyRelationFieldGlue(options).asProxy()
+        return new ManyRelationFieldGlue(options)
     }
     if (metadata.choice_model_path) {
-        return new RelationFieldGlue(options).asProxy()
+        return new RelationFieldGlue(options)
     }
     if (Array.isArray(metadata.choices)) {
-        return new ChoiceFieldGlue(options).asProxy()
+        return new ChoiceFieldGlue(options)
     }
 
-    return new FieldGlue(options).asProxy()
+    return new FieldGlue(options)
 }
 
 export {

--- a/client_js/src/proxies/fields/relation.js
+++ b/client_js/src/proxies/fields/relation.js
@@ -5,6 +5,9 @@ class RelationFieldGlue extends ChoiceFieldGlue {
     static loadingCache = new Map()
 
     get choices() {
+        if (this.choice_model_path) {
+            this.ensureChoices([])
+        }
         return this._choices || []
     }
 
@@ -27,17 +30,11 @@ class RelationFieldGlue extends ChoiceFieldGlue {
     get selectedChoice() {
         const pk = this.pk
         if (pk == null) return undefined
-        return (this.choices || []).find(choice => Number(choice.pk) === Number(pk))
+        return (this._choices || []).find(choice => Number(choice.pk) === Number(pk))
     }
 
     get selectedLabel() {
         return this.selectedChoice?.__str__ ?? ''
-    }
-
-    _handlePropertyAccess(prop, receiver) {
-        if (prop === 'choices' && this.choice_model_path) {
-            receiver.ensureChoices([])
-        }
     }
 
     buildChoices(...choiceFields) {

--- a/django_glue/encoders.py
+++ b/django_glue/encoders.py
@@ -1,11 +1,38 @@
 import json
 
-from django.core.files.uploadedfile import UploadedFile
+from django.core.files.base import File
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Model, QuerySet
-from django.db.models.fields.files import FieldFile
 from django.forms import model_to_dict
 from pydantic import BaseModel
+
+
+def _serialize_file(file: File) -> dict | None:
+    """Serialize a Django File object to a dict.
+
+    Includes name, url, and path when available. Size is intentionally omitted
+    because it requires a HEAD request to remote storage backends like S3,
+    which adds ~70ms latency per file.
+    """
+    result = {'name': file.name}
+
+    # url - only FieldFile has this, and only if file exists
+    try:
+        result['url'] = file.url
+    except (AttributeError, ValueError):
+        # AttributeError: UploadedFile doesn't have url
+        # ValueError: No file associated with this field
+        pass
+
+    # path - only local storage backends support this
+    try:
+        result['path'] = file.path
+    except (AttributeError, NotImplementedError):
+        # AttributeError: UploadedFile doesn't have path
+        # NotImplementedError: Remote storage (S3, etc.) doesn't support absolute paths
+        pass
+
+    return result or None
 
 
 class GlueResponseJSONEncoder(DjangoJSONEncoder):
@@ -19,18 +46,8 @@ class GlueResponseJSONEncoder(DjangoJSONEncoder):
         if isinstance(obj, QuerySet):
             return [model_to_dict(item) for item in obj]
 
-        if isinstance(obj, FieldFile):
-            try:
-                return {'name': obj.name, 'size': obj.size}
-                # return {'name': obj.name, 'size': obj.size, 'url': obj.url, 'path': obj.path}
-            except ValueError:
-                return None
-
-        if isinstance(obj, UploadedFile):
-            try:
-                return {'name': obj.name, 'size': obj.size}
-            except ValueError:
-                return None
+        if isinstance(obj, File):
+            return _serialize_file(obj)
 
         # Handle memoryview objects (returned by PostgreSQL for BinaryField)
         if isinstance(obj, memoryview):

--- a/django_glue/glue/attributes/django/model/field.py
+++ b/django_glue/glue/attributes/django/model/field.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from django.db.models.fields.files import FieldFile
-
 from django_glue.glue.attributes.django.field import BaseDjangoFieldGlueAttribute
 
 if TYPE_CHECKING:
@@ -59,22 +57,7 @@ class ModelFieldAttribute(BaseDjangoFieldGlueAttribute):
                 for obj in self.field.value_from_object(self.instance)
             ]
 
-        value = self.field.value_from_object(self.instance)
-        if isinstance(value, FieldFile):
-            return self._serialize_field_file(value)
-        return value
-
-    @staticmethod
-    def _serialize_field_file(value: FieldFile) -> dict[str, Any] | None:
-        try:
-            return {
-                'name': value.name,
-                # 'size': value.size,
-                # 'url': value.url,
-                # 'path': value.path,
-            }
-        except ValueError:
-            return None
+        return self.field.value_from_object(self.instance)
 
     def set(self, value: Any) -> None:
         if self.field.editable:

--- a/django_glue/tests/glue/test_adapters.py
+++ b/django_glue/tests/glue/test_adapters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from functools import cached_property
 from types import SimpleNamespace
 
@@ -23,6 +24,7 @@ from django_glue.glue import (
     GlueObjectResolverRegistry,
 )
 from django_glue.glue.attributes import DeclaredAttribute, CompositeStateAttribute, GlueObjectAttribute
+from django_glue.encoders import GlueResponseJSONEncoder
 from django_glue.exceptions import GlueCalledStateAttributeError, GlueInvalidPolicyError
 from django_glue.glue.schemas import AttributeCallResolverContext
 from test_project.gorilla.models import Gorilla, Skill
@@ -540,17 +542,15 @@ class DjangoModelGlueObjectTestCase(TestCase):
             **glue_context(access=GlueAccess.VIEW),
             fields=['profile_photo'],
         ))
-        policy = glue_object.policy
 
-        state = glue_object.state
+        # Simulate the actual HTTP flow: state is JSON-encoded before being sent to frontend
+        state = json.loads(json.dumps(glue_object.state, cls=GlueResponseJSONEncoder))
 
-        self.assertTrue(
-            state['profile_photo']['value']['name'].startswith('gorilla_photos/profile-photo')
-        )
-        self.assertTrue(
-            state['profile_photo']['value']['url'].startswith('/media/gorilla_photos/profile-photo')
-        )
-        self.assertGreater(state['profile_photo']['value']['size'], 0)
+        file_value = state['profile_photo']['value']
+        self.assertTrue(file_value['name'].startswith('gorilla_photos/profile-photo'))
+        self.assertTrue(file_value['url'].startswith('/media/gorilla_photos/profile-photo'))
+        self.assertIn('path', file_value)  # Local storage supports path
+        self.assertNotIn('size', file_value)  # Size is omitted for performance
 
     def test_model_adapter_reconstructs_model_reconstruct_from_policy(self):
         glue_object = with_request(ModelGlue(

--- a/django_glue/tests/test_encoders.py
+++ b/django_glue/tests/test_encoders.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, PropertyMock
+
+from django.core.files.base import ContentFile, File
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from django_glue.encoders import GlueResponseJSONEncoder, _serialize_file
+
+
+class SerializeFileTestCase(TestCase):
+    """Tests for the _serialize_file helper function."""
+
+    def test_serialize_file_includes_name(self):
+        file = Mock(spec=File)
+        file.name = 'test.txt'
+
+        result = _serialize_file(file)
+
+        self.assertEqual(result['name'], 'test.txt')
+
+    def test_serialize_file_includes_url_when_available(self):
+        file = Mock(spec=File)
+        file.name = 'test.txt'
+        file.url = '/media/test.txt'
+
+        result = _serialize_file(file)
+
+        self.assertEqual(result['url'], '/media/test.txt')
+
+    def test_serialize_file_includes_path_when_available(self):
+        file = Mock(spec=File)
+        file.name = 'test.txt'
+        file.path = '/var/media/test.txt'
+
+        result = _serialize_file(file)
+
+        self.assertEqual(result['path'], '/var/media/test.txt')
+
+    def test_serialize_file_omits_url_on_value_error(self):
+        """url raises ValueError when no file is associated."""
+        file = Mock(spec=File)
+        file.name = 'test.txt'
+        type(file).url = PropertyMock(side_effect=ValueError('No file'))
+
+        result = _serialize_file(file)
+
+        self.assertNotIn('url', result)
+        self.assertEqual(result['name'], 'test.txt')
+
+    def test_serialize_file_omits_path_on_not_implemented_error(self):
+        """path raises NotImplementedError for remote storage backends."""
+        file = Mock(spec=File)
+        file.name = 'test.txt'
+        file.url = 'https://s3.example.com/test.txt'
+        type(file).path = PropertyMock(side_effect=NotImplementedError())
+
+        result = _serialize_file(file)
+
+        self.assertNotIn('path', result)
+        self.assertEqual(result['name'], 'test.txt')
+        self.assertEqual(result['url'], 'https://s3.example.com/test.txt')
+
+    def test_serialize_file_does_not_include_size(self):
+        """Size is intentionally omitted for performance with remote storage."""
+        file = Mock(spec=File)
+        file.name = 'test.txt'
+        file.size = 1234
+
+        result = _serialize_file(file)
+
+        self.assertNotIn('size', result)
+
+
+class GlueResponseJSONEncoderFileTestCase(TestCase):
+    """Tests for File serialization via GlueResponseJSONEncoder."""
+
+    def test_encoder_serializes_uploaded_file(self):
+        uploaded = SimpleUploadedFile('upload.txt', b'content')
+
+        result = json.loads(json.dumps(uploaded, cls=GlueResponseJSONEncoder))
+
+        self.assertEqual(result['name'], 'upload.txt')
+        self.assertNotIn('size', result)
+
+    def test_encoder_serializes_content_file(self):
+        content_file = ContentFile(b'content', name='content.txt')
+
+        result = json.loads(json.dumps(content_file, cls=GlueResponseJSONEncoder))
+
+        self.assertEqual(result['name'], 'content.txt')


### PR DESCRIPTION
- Remove asProxy() wrapper from FieldGlue, use field instances directly
- Move FK choices lazy-loading into choices getter
- Omit file size from serialization (requires S3 HEAD request, ~70ms)
- Centralize file serialization in encoder with name, url, path